### PR TITLE
Update eslint peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "license": "MIT",
   "peerDependencies": {
-    "eslint": "2.x - 5.x"
+    "eslint": "2 - 6"
   },
   "dependencies": {
     "eslint-module-utils": "^2.2.0",


### PR DESCRIPTION
Adds support for `eslint@6`; fixes https://github.com/janpaul123/eslint-plugin-import-order-alphabetical/issues/7.

I also simplified the semver syntax — the `.x` is unnecessary, as you can verify with this tool: https://semver.npmjs.com.

@janpaul123 could we please publish the next version as `1.0.0`? Managing `0.0.x` dependencies in projects is a hassle 🙏